### PR TITLE
daemon: fix build with musl libc

### DIFF
--- a/daemon.c
+++ b/daemon.c
@@ -922,6 +922,7 @@ I<wait(2)>
 #ifdef _RESTORE_POSIX_SOURCE
 #define _POSIX_SOURCE
 #endif
+#include <sys/ttydefaults.h>
 #include <dirent.h>
 #include <sys/wait.h>
 #include <sys/stat.h>


### PR DESCRIPTION
musl requires the ttydefaults.h to be included explicitly for CEOF.

Signed-off-by: Baruch Siach <baruch@tkos.co.il>