### PR TITLE
Fix build with NDEBUG defined

### DIFF
--- a/libslack/err.h
+++ b/libslack/err.h
@@ -40,10 +40,10 @@
 #undef check
 
 #ifdef NDEBUG
-#define debug(args)
-#define vdebug(args)
-#define debugsys(args)
-#define vdebugsys(args)
+#define debug(args) do {} while (0);
+#define vdebug(args) do {} while (0);
+#define debugsys(args) do {} while (0);
+#define vdebugsys(args) do {} while (0);
 #define check(cond, mesg) (void_cast(0))
 #else
 #define debug(args) debugf args;


### PR DESCRIPTION
Build with NDEBUG fails because the debug() macro becomes empty. This
creates invalid syntax with the debug() call is the only statement in
the body of a 'for' loop.

This fixes build failures like:

daemon.c: In function 'show':
daemon.c:3607:2: error: expected expression before '}' token
  }
  ^