### PR TITLE
daemon: fix build with musl libc (again)

### DIFF
--- a/daemon.c
+++ b/daemon.c
@@ -1011,9 +1011,6 @@ I<elogind(8)>
 #ifdef _RESTORE_POSIX_SOURCE
 #define _POSIX_SOURCE
 #endif
-#ifdef HAVE_SYS_TTYDEFAULTS_H /* For CEOF in musl libc (Linux only) */
-#include <sys/ttydefaults.h>
-#endif
 #include <dirent.h>
 #include <sys/wait.h>
 #include <sys/stat.h>
@@ -1035,6 +1032,10 @@ I<elogind(8)>
 
 #ifdef HAVE_LOGIND
 #include <systemd/sd-login.h>
+#endif
+
+#ifdef HAVE_SYS_TTYDEFAULTS_H /* For CEOF in musl libc (Linux only) */
+#include <sys/ttydefaults.h>
 #endif
 
 /* Configuration file entries */


### PR DESCRIPTION
Commit 6b28c54dd95b3 added HAVE_SYS_TTYDEFAULTS_H to guard
sys/ttydefaults.h include. This breaks musl libc build because
HAVE_SYS_TTYDEFAULTS_H is not defined until config.h is included.

Move sys/ttydefaults.h include below config.h